### PR TITLE
Buildah index.html path

### DIFF
--- a/documentation/_include/buildah.adoc
+++ b/documentation/_include/buildah.adoc
@@ -114,7 +114,7 @@ Do the following (using the path returned by buildah for the cd command):
 [source]
 ----
 cd /var/lib/containers/storage/overlay/669b69de30cf8a39eafabccddb6a6e1db7d8d707e6a76c552518f4a8ed716cef/merged
-ls -lah /var/www/html
+ls -lah var/www/html
 ----
 
 and you should see:
@@ -127,7 +127,7 @@ drwxr-xr-x. 1 importantuser root 18 Apr 19 02:13 ..
 -rw-r--r--. 1 importantuser root 58 May  2 14:54 test.txt
 ----
 
-There is our test.txt! Let's add the following as /var/www/html/index.html:
+There is our test.txt! Let's add the following as var/www/html/index.html:
 
 [source]
 ----
@@ -147,7 +147,7 @@ Once you have written that, you should be able to run:
 
 [source]
 ----
-ls -lahZ /var/www/html/
+ls -lahZ var/www/html/
 ----
 
 and see:


### PR DESCRIPTION
Removed the slash at the beginning of /var/www/html, this had the student writing to the root file system, not to the mounted container's file system.